### PR TITLE
Add roslibpy package

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,7 @@ jobs:
         - ptvsd
         - pydevd
         - pyinstrument_cext
+        - roslibpy
 
     steps:
     - uses: actions/checkout@v2

--- a/packages.toml
+++ b/packages.toml
@@ -23,6 +23,9 @@ version = "2.7.0"
 [packages.pyinstrument_cext]
 version = "0.2.4"
 
+[packages.roslibpy]
+version = "1.2.1"
+
 # TODO
 # [packages.scipy]
 # version = "1.5.3"


### PR DESCRIPTION
This is a handy package for facilitating ROS communication
to a coprosessor or similar without having to install an
entire ros stack on the RIO