### PR TITLE
Add pyinstrument 4.4.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
         - numpy
         - ptvsd
         - pydevd
-        - pyinstrument_cext
+        - pyinstrument
         - PyYAML
         - zope.interface
 

--- a/packages.toml
+++ b/packages.toml
@@ -28,8 +28,8 @@ version = "4.3.2"
 [packages.pydevd]
 version = "2.9.1"
 
-[packages.pyinstrument_cext]
-version = "0.2.4"
+[packages.pyinstrument]
+version = "4.4.0"
 
 [packages."PyYAML"]
 version = "6.0"


### PR DESCRIPTION
From https://github.com/joerick/pyinstrument_cext#readme

> Since Pyinstrument 4.0, this library has been folded into pyinstrument.

Per this, build pyinstrument instead.