### PR TITLE
Add cffi 1.16.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,6 +21,7 @@ jobs:
         #
 
         package:
+        - cffi
         - Cython
         - debugpy
         - numpy

--- a/packages.toml
+++ b/packages.toml
@@ -1,3 +1,5 @@
+[packages.cffi]
+version = "1.16.0"
 
 [packages.Cython]
 version = "3.0.8"


### PR DESCRIPTION
Opening this draft so we have a thread to work on getting this to build.

From Dustin's [comment](https://github.com/robotpy/roborio-wheels/pull/7#issuecomment-1094339253):

> You would probably need to download the opkg that NI created for libffi, unpack it, and somehow point cffi at it.
>
> It looks like you can configure cffi's ffi library via pkg-config... https://github.com/python-cffi/cffi/blob/640e89fa97bd18bc4f69e714a4962284b83d5a76/setup.py#L20