### PR TITLE
Add Shapely 2.0.7

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,6 +31,7 @@ jobs:
         - PyYAML
         - yappi
         - zope.interface
+        - shapely
 
     steps:
     - uses: actions/checkout@v4

--- a/packages.toml
+++ b/packages.toml
@@ -83,3 +83,6 @@ version = "7.1.0"
 
 [packages.yappi]
 version = "1.6.0"
+
+[packages.shapely]
+version = "2.0.7"


### PR DESCRIPTION
Used for calculating if the pose estimate from the Limelight is within the field's boundaries given the the field is not a rectangle.