### PR TITLE
Shapely

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,11 +29,15 @@ jobs:
         - pydevd
         - pyinstrument
         - PyYAML
+        - shapely
         - yappi
         - zope.interface
 
     steps:
     - uses: actions/checkout@v4
+
+    # temporary fix needed for shapely
+    - run: apt-get update && apt-get install -y bzip2
 
     # temporary fix
     - run: /build/venv/bin/cross-python -m pip config set global.extra-index-url https://wpilib.jfrog.io/artifactory/api/pypi/wpilib-python-release-2025/simple

--- a/packages.toml
+++ b/packages.toml
@@ -81,8 +81,8 @@ build_pip_requirements = [
 version = "2.0.7"
 build_pip_requirements = [
     "setuptools",
-    "Cython>=3.0",
-    "numpy==2.2.1",
+    "Cython==3.0.10",
+    "numpy",
 ]
 pre_script = "scripts/build_geos.sh"
 

--- a/packages.toml
+++ b/packages.toml
@@ -77,6 +77,19 @@ build_pip_requirements = [
 # [packages.scipy]
 # version = "1.5.3"
 
+[packages.shapely]
+version = "2.0.7"
+build_pip_requirements = [
+    "setuptools",
+    "Cython>=3.0",
+    "numpy==2.2.1",
+]
+pre_script = "scripts/build_geos.sh"
+
+[packages.shapely.environment]
+GEOS_CONFIG = "/usr/local/arm-nilrt-linux-gnueabi/sysroot/usr/bin/geos-config"
+
+
 [packages."zope.interface"]
 version = "7.1.0"
 # mod_version = "6.1+r2"

--- a/roborio-toolchain.cmake
+++ b/roborio-toolchain.cmake
@@ -1,0 +1,17 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Linux)
+
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER   arm-frc2025-linux-gnueabi-gcc)
+set(CMAKE_CXX_COMPILER arm-frc2025-linux-gnueabi-g++)
+
+# where is the target environment located
+set(CMAKE_FIND_ROOT_PATH /usr/local/arm-nilrt-linux-gnueabi/sysroot)
+
+# adjust the default behavior of the FIND_XXX() commands:
+# search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/scripts/build_geos.sh
+++ b/scripts/build_geos.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+/build/venv/bin/build-pip install cmake ninja
+
+[ -f geos-3.13.0.tar.bz2 ] || wget https://download.osgeo.org/geos/geos-3.13.0.tar.bz2
+[ -d geos-3.13.0 ] || tar -xf geos-3.13.0.tar.bz2
+
+cd geos-3.13.0/
+
+mkdir build
+cd build
+/build/venv/build/bin/cmake \
+    -DCMAKE_TOOLCHAIN_FILE=../../roborio-toolchain.cmake \
+    -DCMAKE_MAKE_PROGRAM=/build/venv/build/bin/ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local/arm-nilrt-linux-gnueabi/sysroot/usr \
+    -DBUILD_DOCUMENTATION=OFF \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -G Ninja \
+    ..
+
+/build/venv/build/bin/cmake --build .
+/build/venv/build/bin/cmake --install .

--- a/whl_build.py
+++ b/whl_build.py
@@ -26,6 +26,13 @@ if __name__ == "__main__":
 
     name = pkgdata.get("name", args.project)
 
+    try:
+        pre_script = pkgdata["pre_script"]
+    except KeyError:
+        pass
+    else:
+        os.system(pre_script)
+
     env = os.environ.copy()
     env["PATH"] = f"{env['PATH']}:/build/venv/build/bin"
     if "environment" in pkgdata:


### PR DESCRIPTION
Supercedes https://github.com/robotpy/roborio-wheels/pull/26, but doesn't work yet. I think that shapely doesn't support cross-compilation because of the way that it detects numpy as a dependency.

shapely depends on libgeos, and what this does is adds a separate step that builds libgeos and installs it into the sysroot (but only with static linking), so in theory if the wheel gets built it should just work. However it fails when trying to link to some numpy stuff.

I've brought this as far as I want to go with it, someone else will need to fix shapely.